### PR TITLE
Fix authentication roles and update PDF path

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -9,13 +9,13 @@ security:
                 users:
                     admin@gmail.com:
                         password: '$2b$12$/UzoPDE0Aoiz4HIUIPZsZu7KxVs3DCwpb.PQp9hTvCFmrM4LY4CBu'
-                        roles: ['ROLE_ADMIN']
+                        roles: ['ROLE_ADMIN', 'ROLE_USER']
                     user@gmail.com:
                         password: '$2b$12$/UzoPDE0Aoiz4HIUIPZsZu7KxVs3DCwpb.PQp9hTvCFmrM4LY4CBu'
                         roles: ['ROLE_USER']
                     agent@gmail.com:
                         password: '$2b$12$/UzoPDE0Aoiz4HIUIPZsZu7KxVs3DCwpb.PQp9hTvCFmrM4LY4CBu'
-                        roles: ['ROLE_AGENT']
+                        roles: ['ROLE_AGENT', 'ROLE_USER']
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -129,7 +129,7 @@ class DashboardController extends AbstractController
     #[Route('/telecharger/devoir', name: 'download_devoir')]
     public function downloadDevoir(): BinaryFileResponse
     {
-        $path = $this->getParameter('kernel.project_dir').'/TP _ Devoir DITI4 30_01_2025.pdf';
-        return $this->file($path, 'TP_Devoir_DITI4_30_01_2025.pdf', ResponseHeaderBag::DISPOSITION_ATTACHMENT);
+        $path = $this->getParameter('kernel.project_dir').'/TP _ Devoir DITI4 14_06_2025 (version corrigée du 30_01_2025).pdf';
+        return $this->file($path, 'TP_Devoir_DITI4_14_06_2025.pdf', ResponseHeaderBag::DISPOSITION_ATTACHMENT);
     }
 }


### PR DESCRIPTION
## Summary
- allow `admin@gmail.com` and `agent@gmail.com` to log in
- update path for downloading the assignment PDF

## Testing
- `php bin/phpunit` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f562c4bc8323b2d2c9e97dbc1f01