### PR TITLE
move zone data to surveillance point

### DIFF
--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -119,14 +119,8 @@ class DashboardController extends AbstractController
                     $zone = new Zone();
                     $zone->setName($name);
                     $zone->setCountry($country);
-                    $population = (int)$request->request->get('population', 0);
-                    $symptomatic = (int)$request->request->get('symptomatic', 0);
-                    $positive = (int)$request->request->get('positive', 0);
-                    $zone->setPopulation($population);
-                    $zone->setSymptomatic($symptomatic);
-                    $zone->setPositive($positive);
-                    $zone->setStatus($this->calculateStatus($population, $symptomatic, $positive));
                     $em->persist($zone);
+                    $this->updateZoneStats($zone);
                     $em->flush();
                     return $this->redirectToRoute('zone_list');
                 }
@@ -148,15 +142,9 @@ class DashboardController extends AbstractController
             if ($name !== '' && $countryId) {
                 $country = $countries->find($countryId);
                 if ($country) {
-                    $population = (int)$request->request->get('population', 0);
-                    $symptomatic = (int)$request->request->get('symptomatic', 0);
-                    $positive = (int)$request->request->get('positive', 0);
                     $zone->setName($name);
                     $zone->setCountry($country);
-                    $zone->setPopulation($population);
-                    $zone->setSymptomatic($symptomatic);
-                    $zone->setPositive($positive);
-                    $zone->setStatus($this->calculateStatus($population, $symptomatic, $positive));
+                    $this->updateZoneStats($zone);
                     $em->flush();
                     return $this->redirectToRoute('zone_list');
                 }
@@ -191,7 +179,14 @@ class DashboardController extends AbstractController
                     $point = new SurveillancePoint();
                     $point->setName($name);
                     $point->setZone($zone);
+                    $population = (int)$request->request->get('population', 0);
+                    $symptomatic = (int)$request->request->get('symptomatic', 0);
+                    $positive = (int)$request->request->get('positive', 0);
+                    $point->setPopulation($population);
+                    $point->setSymptomatic($symptomatic);
+                    $point->setPositive($positive);
                     $em->persist($point);
+                    $this->updateZoneStats($zone);
                     $em->flush();
                     return $this->redirectToRoute('point_list');
                 }
@@ -214,8 +209,19 @@ class DashboardController extends AbstractController
             if ($name !== '' && $zoneId) {
                 $zone = $zones->find($zoneId);
                 if ($zone) {
+                    $oldZone = $point->getZone();
                     $point->setName($name);
                     $point->setZone($zone);
+                    $population = (int)$request->request->get('population', 0);
+                    $symptomatic = (int)$request->request->get('symptomatic', 0);
+                    $positive = (int)$request->request->get('positive', 0);
+                    $point->setPopulation($population);
+                    $point->setSymptomatic($symptomatic);
+                    $point->setPositive($positive);
+                    $this->updateZoneStats($oldZone);
+                    if ($oldZone !== $zone) {
+                        $this->updateZoneStats($zone);
+                    }
                     $em->flush();
                     return $this->redirectToRoute('point_list');
                 }
@@ -233,7 +239,9 @@ class DashboardController extends AbstractController
     #[IsGranted('ROLE_AGENT')]
     public function deletePoint(SurveillancePoint $point, EntityManagerInterface $em): Response
     {
+        $zone = $point->getZone();
         $em->remove($point);
+        $this->updateZoneStats($zone);
         $em->flush();
         return $this->redirectToRoute('point_list');
     }
@@ -285,6 +293,9 @@ class DashboardController extends AbstractController
             $pts[] = [
                 'name' => $point->getName(),
                 'zone' => $point->getZone()->getName(),
+                'population' => $point->getPopulation(),
+                'symptomatic' => $point->getSymptomatic(),
+                'positive' => $point->getPositive(),
             ];
         }
 
@@ -293,6 +304,24 @@ class DashboardController extends AbstractController
             'zones' => $zones,
             'points' => $pts,
         ]);
+    }
+
+    private function updateZoneStats(Zone $zone): void
+    {
+        $population = 0;
+        $symptomatic = 0;
+        $positive = 0;
+
+        foreach ($zone->getPoints() as $p) {
+            $population += $p->getPopulation() ?? 0;
+            $symptomatic += $p->getSymptomatic() ?? 0;
+            $positive += $p->getPositive() ?? 0;
+        }
+
+        $zone->setPopulation($population);
+        $zone->setSymptomatic($symptomatic);
+        $zone->setPositive($positive);
+        $zone->setStatus($this->calculateStatus($population, $symptomatic, $positive));
     }
 
     private function calculateStatus(int $population, int $symptomatic, int $positive): string

--- a/src/Entity/SurveillancePoint.php
+++ b/src/Entity/SurveillancePoint.php
@@ -19,6 +19,15 @@ class SurveillancePoint
     #[ORM\JoinColumn(nullable: false)]
     private ?Zone $zone = null;
 
+    #[ORM\Column(type: 'integer')]
+    private ?int $population = null;
+
+    #[ORM\Column(type: 'integer')]
+    private ?int $symptomatic = null;
+
+    #[ORM\Column(type: 'integer')]
+    private ?int $positive = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -43,6 +52,39 @@ class SurveillancePoint
     public function setZone(?Zone $zone): self
     {
         $this->zone = $zone;
+        return $this;
+    }
+
+    public function getPopulation(): ?int
+    {
+        return $this->population;
+    }
+
+    public function setPopulation(int $population): self
+    {
+        $this->population = $population;
+        return $this;
+    }
+
+    public function getSymptomatic(): ?int
+    {
+        return $this->symptomatic;
+    }
+
+    public function setSymptomatic(int $symptomatic): self
+    {
+        $this->symptomatic = $symptomatic;
+        return $this;
+    }
+
+    public function getPositive(): ?int
+    {
+        return $this->positive;
+    }
+
+    public function setPositive(int $positive): self
+    {
+        $this->positive = $positive;
         return $this;
     }
 }

--- a/templates/admin/point_edit.html.twig
+++ b/templates/admin/point_edit.html.twig
@@ -26,6 +26,20 @@
                             {% endfor %}
                         </select>
                     </div>
+                    <div class="form-row">
+                        <div class="form-group col-md-4">
+                            <label for="pointHabitants">Habitants</label>
+                            <input type="number" class="form-control" id="pointHabitants" name="population" value="{{ point.population }}">
+                        </div>
+                        <div class="form-group col-md-4">
+                            <label for="pointSympto">Symptomatiques</label>
+                            <input type="number" class="form-control" id="pointSympto" name="symptomatic" value="{{ point.symptomatic }}">
+                        </div>
+                        <div class="form-group col-md-4">
+                            <label for="pointPositifs">Cas confirmés</label>
+                            <input type="number" class="form-control" id="pointPositifs" name="positive" value="{{ point.positive }}">
+                        </div>
+                    </div>
                     <button type="submit" class="btn btn-primary">Enregistrer</button>
                 </form>
             </div>

--- a/templates/admin/point_list.html.twig
+++ b/templates/admin/point_list.html.twig
@@ -14,6 +14,9 @@
                             <tr>
                                 <th>Nom</th>
                                 <th>Zone</th>
+                                <th>Habitants</th>
+                                <th>Symptomatiques</th>
+                                <th>Confirmés</th>
                                 {% if is_granted('ROLE_AGENT') %}<th>Actions</th>{% endif %}
                             </tr>
                         </thead>
@@ -22,6 +25,9 @@
                                 <tr>
                                     <td>{{ point.name }}</td>
                                     <td>{{ point.zone.name }}</td>
+                                    <td>{{ point.population }}</td>
+                                    <td>{{ point.symptomatic }}</td>
+                                    <td>{{ point.positive }}</td>
                                     {% if is_granted('ROLE_AGENT') %}
                                         <td>
                                             <a href="{{ path('point_edit', {id: point.id}) }}" class="btn btn-sm btn-primary">Modifier</a>

--- a/templates/admin/point_new.html.twig
+++ b/templates/admin/point_new.html.twig
@@ -30,6 +30,20 @@
 
                         </select>
                     </div>
+                    <div class="form-row">
+                        <div class="form-group col-md-4">
+                            <label for="pointHabitants">Habitants</label>
+                            <input type="number" class="form-control" id="pointHabitants" name="population">
+                        </div>
+                        <div class="form-group col-md-4">
+                            <label for="pointSympto">Symptomatiques</label>
+                            <input type="number" class="form-control" id="pointSympto" name="symptomatic">
+                        </div>
+                        <div class="form-group col-md-4">
+                            <label for="pointPositifs">Cas confirmés</label>
+                            <input type="number" class="form-control" id="pointPositifs" name="positive">
+                        </div>
+                    </div>
                     <button type="submit" class="btn btn-primary">Enregistrer</button>
                 </form>
             </div>

--- a/templates/admin/view_map.html.twig
+++ b/templates/admin/view_map.html.twig
@@ -173,7 +173,13 @@
                 });
 
                 marker.addListener('mouseover', function() {
-                    pointInfo.setContent('<strong>' + p.name + '</strong><br>Zone: ' + p.zone);
+                    pointInfo.setContent(
+                        '<strong>' + p.name + '</strong><br>' +
+                        'Zone: ' + p.zone + '<br>' +
+                        'Habitants: ' + p.population + '<br>' +
+                        'Symptomatiques: ' + p.symptomatic + '<br>' +
+                        'Confirmés: ' + p.positive
+                    );
                     pointInfo.open(map, marker);
                 });
                 marker.addListener('mouseout', function() {

--- a/templates/admin/zone_edit.html.twig
+++ b/templates/admin/zone_edit.html.twig
@@ -21,20 +21,7 @@
                             {% endfor %}
                         </select>
                     </div>
-                    <div class="form-row">
-                        <div class="form-group col-md-4">
-                            <label for="zoneHabitants">Habitants</label>
-                            <input type="number" class="form-control" id="zoneHabitants" name="population" value="{{ zone.population }}">
-                        </div>
-                        <div class="form-group col-md-4">
-                            <label for="zoneSympto">Symptomatiques</label>
-                            <input type="number" class="form-control" id="zoneSympto" name="symptomatic" value="{{ zone.symptomatic }}">
-                        </div>
-                        <div class="form-group col-md-4">
-                            <label for="zonePositifs">Cas confirmés</label>
-                            <input type="number" class="form-control" id="zonePositifs" name="positive" value="{{ zone.positive }}">
-                        </div>
-                    </div>
+                    {# Les compteurs sont mis à jour à partir des points de surveillance #}
                     <button type="submit" class="btn btn-primary">Enregistrer</button>
                 </form>
             </div>

--- a/templates/admin/zone_new.html.twig
+++ b/templates/admin/zone_new.html.twig
@@ -25,22 +25,7 @@
 
                         </select>
                     </div>
-                    <div class="form-row">
-                        <div class="form-group col-md-4">
-                            <label for="zoneHabitants">Habitants</label>
-                            <input type="number" class="form-control" id="zoneHabitants" name="population">
-                        </div>
-                        <div class="form-group col-md-4">
-                            <label for="zoneSympto">Symptomatiques</label>
-                            <input type="number" class="form-control" id="zoneSympto" name="symptomatic">
-                        </div>
-                        <div class="form-group col-md-4">
-                            <label for="zonePositifs">Cas confirmés</label>
-                            <input type="number" class="form-control" id="zonePositifs" name="positive">
-
-                        </div>
-                    </div>
-                    {# Le statut est calculé automatiquement #}
+                    {# Les compteurs sont renseignés automatiquement via les points de surveillance #}
                     <button type="submit" class="btn btn-primary">Enregistrer</button>
                 </form>
             </div>


### PR DESCRIPTION
## Summary
- store population info on surveillance points instead of zones
- recalc zone stats from its points when points change
- update templates and controller logic to use the new fields
- display hospital data on the map and in lists

## Testing
- `php -l src/Controller/DashboardController.php`
- `php -l src/Entity/SurveillancePoint.php`
- `php -l templates/admin/point_new.html.twig`
- `php -l templates/admin/point_edit.html.twig`
- `php -l templates/admin/point_list.html.twig`
- `php -l templates/admin/zone_new.html.twig`
- `php -l templates/admin/zone_edit.html.twig`
- `php -l templates/admin/view_map.html.twig`
- `find src templates -name '*.php' -o -name '*.twig' | xargs -I{} php -l {}`
- `vendor/bin/phpunit --configuration phpunit.dist.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6871ac321b24832398f8b3210d8ae09b