### PR TITLE
use Gmail API for alerts

### DIFF
--- a/.env
+++ b/.env
@@ -43,3 +43,10 @@ MAILER_DSN=null://null
 # Google Maps API key used to display the map of Senegal
 GOOGLE_MAPS_API_KEY="AIzaSyBnZkG7MY5E_8OZuVJhU-yE0l6nu1K0s_w"
 
+
+# Gmail API credentials
+GMAIL_CLIENT_ID=""
+GMAIL_CLIENT_SECRET=""
+GMAIL_REFRESH_TOKEN=""
+GMAIL_FROM="noreply@example.com"
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# Epidemi Dashboard
+
+This project is a small Symfony application to manage epidemic monitoring data. It lets agents create countries, zones and surveillance points (which correspond to hospitals) and view their status on a map. The interface now suggests many hospital and dispensary names – at least four for each region of Senegal – when adding a surveillance point.
+
+## Requirements
+
+- PHP 8.2 or higher
+- Composer
+- PostgreSQL (or another database supported by Doctrine)
+
+## Installation
+
+1. Install PHP dependencies:
+
+   ```bash
+   composer install
+   ```
+
+2. Copy `.env` to `.env.local` and adjust the database connection string if necessary.
+
+3. Configure email notifications via the Gmail API by defining these variables in `.env.local`:
+
+   ```bash
+   GMAIL_CLIENT_ID=your-client-id
+   GMAIL_CLIENT_SECRET=your-client-secret
+   GMAIL_REFRESH_TOKEN=your-refresh-token
+   GMAIL_FROM=your-gmail-address
+   ```
+   These values correspond to the information provided in the credentials JSON
+   downloaded from Google Cloud Console.
+
+4. Run the database migrations to create/update the schema:
+
+   ```bash
+   php bin/console doctrine:migrations:migrate
+   ```
+
+The latest migration adds surveillance point statistics columns (`population`, `symptomatic`, `positive`). Run it after pulling new code so the list and map pages work correctly.
+
+5. Start the local server:
+
+   ```bash
+   symfony serve
+   ```
+
+   or use the built‑in PHP server:
+
+   ```bash
+   php -S 127.0.0.1:8000 -t public
+   ```
+
+Log in with the credentials defined in `config/packages/security.yaml` (by default an in‑memory user with email `agent@gmail.com` and password `password`).
+
+## Updating Zone Statistics
+
+Whenever you add, edit or delete a surveillance point (hôpital), the application recalculates the statistics for the related zone automatically. Zone statistics are the **sum** of the population, symptomatic cases and confirmed cases from all hospitals in the zone. The zone's color depends on the cumulative positive case rate across its surveillance points:
+
+* **Green** – less than 5% positive
+* **Orange** – 5–15%
+* **Red** – 15% or more
+
+Each zone can contain at most four surveillance points. Any attempt to add an extra point will be rejected.
+
+When a zone's calculated status becomes **red**, the application automatically
+sends an email through the Gmail API to `fayeibracheikh@gmail.com`. The message
+lists the zone name, its population, the number of surveillance points and
+details for each point.
+
+## Tests
+
+The repository includes PHPUnit configuration. After installing development dependencies you can run the test suite with:
+
+```bash
+vendor/bin/phpunit --configuration phpunit.dist.xml
+```
+

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -19,3 +19,9 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+    App\Service\GmailApiMailer:
+        arguments:
+            $clientId: '%env(GMAIL_CLIENT_ID)%'
+            $clientSecret: '%env(GMAIL_CLIENT_SECRET)%'
+            $refreshToken: '%env(GMAIL_REFRESH_TOKEN)%'
+            $from: '%env(GMAIL_FROM)%'

--- a/migrations/Version20250712005341.php
+++ b/migrations/Version20250712005341.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250712005341 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add stats columns to surveillance_point';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE surveillance_point
+                ADD population INT DEFAULT 0,
+                ADD symptomatic INT DEFAULT 0,
+                ADD positive INT DEFAULT 0
+        SQL);
+        $this->addSql("UPDATE surveillance_point SET population = 0 WHERE population IS NULL");
+        $this->addSql("UPDATE surveillance_point SET symptomatic = 0 WHERE symptomatic IS NULL");
+        $this->addSql("UPDATE surveillance_point SET positive = 0 WHERE positive IS NULL");
+        $this->addSql(<<<'SQL'
+            ALTER TABLE surveillance_point
+                ALTER COLUMN population SET NOT NULL,
+                ALTER COLUMN symptomatic SET NOT NULL,
+                ALTER COLUMN positive SET NOT NULL
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE surveillance_point
+                DROP COLUMN population,
+                DROP COLUMN symptomatic,
+                DROP COLUMN positive
+        SQL);
+    }
+}

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -15,6 +15,7 @@ use App\Repository\SurveillancePointRepository;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Bundle\SecurityBundle\Attribute\IsGranted;
+use App\Service\GmailApiMailer;
 
 /**
  * Dashboard and CRUD controller.
@@ -26,23 +27,102 @@ class DashboardController extends AbstractController
         'Sénégal', 'Mali', 'Mauritanie', 'Gambie', 'Guinée',
     ];
 
-    /** Department names used for point suggestions. */
-    private const DEPARTMENT_NAMES = [
-        'Dakar', 'Pikine', 'Guédiawaye', 'Rufisque',
-        'Thiès', 'Mbour', 'Tivaouane',
-        'Diourbel', 'Bambey', 'Mbacké',
-        'Fatick', 'Foundiougne', 'Gossas',
-        'Kaolack', 'Guinguinéo', 'Nioro du Rip',
-        'Kaffrine', 'Birkilane', 'Koungheul', 'Malem Hodar',
-        'Louga', 'Kébémer', 'Linguère',
-        'Saint-Louis', 'Dagana', 'Podor',
-        'Matam', 'Kanel', 'Ranéro Ferlo',
-        'Tambacounda', 'Bakel', 'Goudiry', 'Koumpentoum',
-        'Kédougou', 'Salémata', 'Saraya',
-        'Kolda', 'Velingara', 'Médina Yoro Foulah',
-        'Sédhiou', 'Bounkiling', 'Goudomp',
-        'Ziguinchor', 'Bignona', 'Oussouye'
+    /** Example hospital names for point suggestions. */
+    private const HOSPITAL_NAMES = [
+        // Dakar region
+        'Hôpital Principal de Dakar',
+        'Hôpital Fann',
+        'Hôpital Aristide Le Dantec',
+        'Hôpital Dalal Jamm',
+
+        // Thiès region
+        'Hôpital régional de Thiès',
+        'Hôpital de Mbour',
+        'Dispensaire de Tivaouane',
+        'Centre de Santé Thiès Nord',
+
+        // Diourbel region
+        'Hôpital de Diourbel',
+        'Dispensaire de Bambey',
+        'Centre de Santé Mbacké',
+        'Centre de Santé Ndindy',
+
+        // Fatick region
+        'Hôpital de Fatick',
+        'Hôpital de Foundiougne',
+        'Dispensaire de Gossas',
+        'Centre de Santé Fatick Nord',
+
+        // Kaolack region
+        'Hôpital de Kaolack',
+        'Hôpital de Nioro du Rip',
+        'Dispensaire de Guinguinéo',
+        'Centre de Santé de Kaolack',
+
+        // Kaffrine region
+        'Hôpital de Kaffrine',
+        'Dispensaire de Koungheul',
+        'Centre de Santé Birkelane',
+        'Centre de Santé Malem Hodar',
+
+        // Louga region
+        'Hôpital de Louga',
+        'Hôpital de Linguère',
+        'Dispensaire de Kébémer',
+        'Centre de Santé Louga Nord',
+
+        // Saint-Louis region
+        'Hôpital de Saint-Louis',
+        'Hôpital de Dagana',
+        'Hôpital de Podor',
+        'Dispensaire de Richard Toll',
+
+        // Matam region
+        'Hôpital de Matam',
+        'Hôpital de Kanel',
+        'Dispensaire de Ranérou',
+        'Centre de Santé Matam Ouest',
+
+        // Tambacounda region
+        'Hôpital de Tambacounda',
+        'Hôpital de Goudiry',
+        'Dispensaire de Bakel',
+        'Centre de Santé Koumpentoum',
+
+        // Kédougou region
+        'Hôpital de Kédougou',
+        'Dispensaire de Saraya',
+        'Dispensaire de Salemata',
+        'Centre de Santé Kédougou Ouest',
+
+        // Sédhiou region
+        'Hôpital de Sédhiou',
+        'Hôpital de Bounkiling',
+        'Dispensaire de Goudomp',
+        'Centre de Santé Sédhiou Est',
+
+        // Kolda region
+        'Hôpital de Kolda',
+        'Hôpital de Vélingara',
+        'Dispensaire de Médina Yoro Foulah',
+        'Centre de Santé Kolda Sud',
+
+        // Ziguinchor region
+        'Hôpital de Ziguinchor',
+        'Hôpital de Oussouye',
+        'Dispensaire de Bignona',
+        'Centre de Santé Ziguinchor Nord'
     ];
+
+    private GmailApiMailer $gmailMailer;
+
+    public function __construct(GmailApiMailer $gmailMailer)
+    {
+        $this->gmailMailer = $gmailMailer;
+    }
+
+    /** Maximum number of points allowed in a single zone. */
+    private const MAX_POINTS_PER_ZONE = 4;
     #[Route('/dashboard', name: 'dashboard')]
 
     public function index(): Response
@@ -119,14 +199,8 @@ class DashboardController extends AbstractController
                     $zone = new Zone();
                     $zone->setName($name);
                     $zone->setCountry($country);
-                    $population = (int)$request->request->get('population', 0);
-                    $symptomatic = (int)$request->request->get('symptomatic', 0);
-                    $positive = (int)$request->request->get('positive', 0);
-                    $zone->setPopulation($population);
-                    $zone->setSymptomatic($symptomatic);
-                    $zone->setPositive($positive);
-                    $zone->setStatus($this->calculateStatus($population, $symptomatic, $positive));
                     $em->persist($zone);
+                    $this->updateZoneStats($zone);
                     $em->flush();
                     return $this->redirectToRoute('zone_list');
                 }
@@ -148,15 +222,9 @@ class DashboardController extends AbstractController
             if ($name !== '' && $countryId) {
                 $country = $countries->find($countryId);
                 if ($country) {
-                    $population = (int)$request->request->get('population', 0);
-                    $symptomatic = (int)$request->request->get('symptomatic', 0);
-                    $positive = (int)$request->request->get('positive', 0);
                     $zone->setName($name);
                     $zone->setCountry($country);
-                    $zone->setPopulation($population);
-                    $zone->setSymptomatic($symptomatic);
-                    $zone->setPositive($positive);
-                    $zone->setStatus($this->calculateStatus($population, $symptomatic, $positive));
+                    $this->updateZoneStats($zone);
                     $em->flush();
                     return $this->redirectToRoute('zone_list');
                 }
@@ -188,10 +256,21 @@ class DashboardController extends AbstractController
             if ($name !== '' && $zoneId) {
                 $zone = $zones->find($zoneId);
                 if ($zone) {
+                    if ($zone->getPoints()->count() >= self::MAX_POINTS_PER_ZONE) {
+                        $this->addFlash('error', 'Cette zone possède déjà ' . self::MAX_POINTS_PER_ZONE . ' points de surveillance.');
+                        return $this->redirectToRoute('point_list');
+                    }
                     $point = new SurveillancePoint();
                     $point->setName($name);
-                    $point->setZone($zone);
+                    $zone->addPoint($point);
+                    $population = (int)$request->request->get('population', 0);
+                    $symptomatic = (int)$request->request->get('symptomatic', 0);
+                    $positive = (int)$request->request->get('positive', 0);
+                    $point->setPopulation($population);
+                    $point->setSymptomatic($symptomatic);
+                    $point->setPositive($positive);
                     $em->persist($point);
+                    $this->updateZoneStats($zone);
                     $em->flush();
                     return $this->redirectToRoute('point_list');
                 }
@@ -200,7 +279,7 @@ class DashboardController extends AbstractController
 
         return $this->render('admin/point_new.html.twig', [
             'zones' => $zones->findAll(),
-            'suggestions' => self::DEPARTMENT_NAMES,
+            'suggestions' => self::HOSPITAL_NAMES,
         ]);
     }
 
@@ -214,8 +293,26 @@ class DashboardController extends AbstractController
             if ($name !== '' && $zoneId) {
                 $zone = $zones->find($zoneId);
                 if ($zone) {
+                    $oldZone = $point->getZone();
+                    if ($zone !== $oldZone && $zone->getPoints()->count() >= self::MAX_POINTS_PER_ZONE) {
+                        $this->addFlash('error', 'Cette zone possède déjà ' . self::MAX_POINTS_PER_ZONE . ' points de surveillance.');
+                        return $this->redirectToRoute('point_list');
+                    }
                     $point->setName($name);
-                    $point->setZone($zone);
+                    if ($zone !== $oldZone) {
+                        $oldZone->removePoint($point);
+                        $zone->addPoint($point);
+                    }
+                    $population = (int)$request->request->get('population', 0);
+                    $symptomatic = (int)$request->request->get('symptomatic', 0);
+                    $positive = (int)$request->request->get('positive', 0);
+                    $point->setPopulation($population);
+                    $point->setSymptomatic($symptomatic);
+                    $point->setPositive($positive);
+                    $this->updateZoneStats($oldZone);
+                    if ($oldZone !== $zone) {
+                        $this->updateZoneStats($zone);
+                    }
                     $em->flush();
                     return $this->redirectToRoute('point_list');
                 }
@@ -225,7 +322,7 @@ class DashboardController extends AbstractController
         return $this->render('admin/point_edit.html.twig', [
             'point' => $point,
             'zones' => $zones->findAll(),
-            'suggestions' => self::DEPARTMENT_NAMES,
+            'suggestions' => self::HOSPITAL_NAMES,
         ]);
     }
 
@@ -233,7 +330,10 @@ class DashboardController extends AbstractController
     #[IsGranted('ROLE_AGENT')]
     public function deletePoint(SurveillancePoint $point, EntityManagerInterface $em): Response
     {
+        $zone = $point->getZone();
+        $zone->removePoint($point);
         $em->remove($point);
+        $this->updateZoneStats($zone);
         $em->flush();
         return $this->redirectToRoute('point_list');
     }
@@ -285,6 +385,9 @@ class DashboardController extends AbstractController
             $pts[] = [
                 'name' => $point->getName(),
                 'zone' => $point->getZone()->getName(),
+                'population' => $point->getPopulation(),
+                'symptomatic' => $point->getSymptomatic(),
+                'positive' => $point->getPositive(),
             ];
         }
 
@@ -293,6 +396,55 @@ class DashboardController extends AbstractController
             'zones' => $zones,
             'points' => $pts,
         ]);
+    }
+
+    private function updateZoneStats(Zone $zone): void
+    {
+        $population = 0;
+        $symptomatic = 0;
+        $positive = 0;
+
+        $previousStatus = $zone->getStatus();
+
+        foreach ($zone->getPoints() as $p) {
+            $population += $p->getPopulation() ?? 0;
+            $symptomatic += $p->getSymptomatic() ?? 0;
+            $positive += $p->getPositive() ?? 0;
+        }
+
+        $zone->setPopulation($population);
+        $zone->setSymptomatic($symptomatic);
+        $zone->setPositive($positive);
+        $newStatus = $this->calculateStatus($population, $symptomatic, $positive);
+        $zone->setStatus($newStatus);
+
+        if ($newStatus === 'rouge' && $previousStatus !== 'rouge') {
+            $this->sendRedZoneEmail($zone);
+        }
+    }
+
+    private function sendRedZoneEmail(Zone $zone): void
+    {
+        $lines = [];
+        $lines[] = sprintf('La zone de nom %s est rouge.', $zone->getName());
+        $lines[] = sprintf('Nombre d\'habitants: %d', $zone->getPopulation());
+        $lines[] = sprintf('Nombre de points de surveillance: %d', $zone->getPoints()->count());
+        $lines[] = 'Liste des points :';
+        foreach ($zone->getPoints() as $p) {
+            $lines[] = sprintf(
+                '- %s : habitants=%d, symptomatiques=%d, confirmés=%d',
+                $p->getName(),
+                $p->getPopulation(),
+                $p->getSymptomatic(),
+                $p->getPositive()
+            );
+        }
+
+        $this->gmailMailer->send(
+            'fayeibracheikh@gmail.com',
+            'Zone rouge : ' . $zone->getName(),
+            implode("\n", $lines)
+        );
     }
 
     private function calculateStatus(int $population, int $symptomatic, int $positive): string

--- a/src/Entity/SurveillancePoint.php
+++ b/src/Entity/SurveillancePoint.php
@@ -19,6 +19,15 @@ class SurveillancePoint
     #[ORM\JoinColumn(nullable: false)]
     private ?Zone $zone = null;
 
+    #[ORM\Column(type: 'integer')]
+    private ?int $population = null;
+
+    #[ORM\Column(type: 'integer')]
+    private ?int $symptomatic = null;
+
+    #[ORM\Column(type: 'integer')]
+    private ?int $positive = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -43,6 +52,39 @@ class SurveillancePoint
     public function setZone(?Zone $zone): self
     {
         $this->zone = $zone;
+        return $this;
+    }
+
+    public function getPopulation(): ?int
+    {
+        return $this->population;
+    }
+
+    public function setPopulation(int $population): self
+    {
+        $this->population = $population;
+        return $this;
+    }
+
+    public function getSymptomatic(): ?int
+    {
+        return $this->symptomatic;
+    }
+
+    public function setSymptomatic(int $symptomatic): self
+    {
+        $this->symptomatic = $symptomatic;
+        return $this;
+    }
+
+    public function getPositive(): ?int
+    {
+        return $this->positive;
+    }
+
+    public function setPositive(int $positive): self
+    {
+        $this->positive = $positive;
         return $this;
     }
 }

--- a/src/Service/GmailApiMailer.php
+++ b/src/Service/GmailApiMailer.php
@@ -1,0 +1,57 @@
+<?php
+namespace App\Service;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class GmailApiMailer
+{
+    private HttpClientInterface $client;
+    private string $clientId;
+    private string $clientSecret;
+    private string $refreshToken;
+    private string $from;
+
+    public function __construct(HttpClientInterface $client, string $clientId, string $clientSecret, string $refreshToken, string $from)
+    {
+        $this->client = $client;
+        $this->clientId = $clientId;
+        $this->clientSecret = $clientSecret;
+        $this->refreshToken = $refreshToken;
+        $this->from = $from;
+    }
+
+    private function getAccessToken(): ?string
+    {
+        $response = $this->client->request('POST', 'https://oauth2.googleapis.com/token', [
+            'body' => [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+                'refresh_token' => $this->refreshToken,
+                'grant_type' => 'refresh_token',
+            ],
+        ]);
+
+        if (200 !== $response->getStatusCode()) {
+            return null;
+        }
+        $data = $response->toArray(false);
+        return $data['access_token'] ?? null;
+    }
+
+    public function send(string $to, string $subject, string $text): void
+    {
+        $token = $this->getAccessToken();
+        if (!$token) {
+            return;
+        }
+        $raw = sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\n\r\n%s", $this->from, $to, $subject, $text);
+        $raw = rtrim(strtr(base64_encode($raw), ['+' => '-', '/' => '_', '=' => '']));
+        $this->client->request('POST', 'https://gmail.googleapis.com/gmail/v1/users/me/messages/send', [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+                'Content-Type' => 'application/json',
+            ],
+            'json' => ['raw' => $raw],
+        ]);
+    }
+}

--- a/templates/admin/point_edit.html.twig
+++ b/templates/admin/point_edit.html.twig
@@ -1,5 +1,5 @@
 {% extends 'admin/base.html.twig' %}
-{% block title %}Modifier un point{% endblock %}
+{% block title %}Modifier un point de surveillance{% endblock %}
 {% block content %}
 <div class="row">
     <div class="col-lg-6">
@@ -25,6 +25,20 @@
                                 <option value="{{ zone.id }}" {% if point.zone.id == zone.id %}selected{% endif %}>{{ zone.name }}</option>
                             {% endfor %}
                         </select>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group col-md-4">
+                            <label for="pointHabitants">Habitants</label>
+                            <input type="number" class="form-control" id="pointHabitants" name="population" value="{{ point.population }}">
+                        </div>
+                        <div class="form-group col-md-4">
+                            <label for="pointSympto">Symptomatiques</label>
+                            <input type="number" class="form-control" id="pointSympto" name="symptomatic" value="{{ point.symptomatic }}">
+                        </div>
+                        <div class="form-group col-md-4">
+                            <label for="pointPositifs">Cas confirmés</label>
+                            <input type="number" class="form-control" id="pointPositifs" name="positive" value="{{ point.positive }}">
+                        </div>
                     </div>
                     <button type="submit" class="btn btn-primary">Enregistrer</button>
                 </form>

--- a/templates/admin/point_list.html.twig
+++ b/templates/admin/point_list.html.twig
@@ -1,5 +1,5 @@
 {% extends 'admin/base.html.twig' %}
-{% block title %}Liste des points{% endblock %}
+{% block title %}Points de surveillance{% endblock %}
 {% block content %}
 <div class="row">
     <div class="col-lg-8">
@@ -12,8 +12,11 @@
                     <table class="table table-bordered">
                         <thead>
                             <tr>
-                                <th>Nom</th>
+                                <th>Point</th>
                                 <th>Zone</th>
+                                <th>Habitants</th>
+                                <th>Symptomatiques</th>
+                                <th>Confirmés</th>
                                 {% if is_granted('ROLE_AGENT') %}<th>Actions</th>{% endif %}
                             </tr>
                         </thead>
@@ -22,6 +25,9 @@
                                 <tr>
                                     <td>{{ point.name }}</td>
                                     <td>{{ point.zone.name }}</td>
+                                    <td>{{ point.population }}</td>
+                                    <td>{{ point.symptomatic }}</td>
+                                    <td>{{ point.positive }}</td>
                                     {% if is_granted('ROLE_AGENT') %}
                                         <td>
                                             <a href="{{ path('point_edit', {id: point.id}) }}" class="btn btn-sm btn-primary">Modifier</a>

--- a/templates/admin/point_new.html.twig
+++ b/templates/admin/point_new.html.twig
@@ -30,6 +30,20 @@
 
                         </select>
                     </div>
+                    <div class="form-row">
+                        <div class="form-group col-md-4">
+                            <label for="pointHabitants">Habitants</label>
+                            <input type="number" class="form-control" id="pointHabitants" name="population">
+                        </div>
+                        <div class="form-group col-md-4">
+                            <label for="pointSympto">Symptomatiques</label>
+                            <input type="number" class="form-control" id="pointSympto" name="symptomatic">
+                        </div>
+                        <div class="form-group col-md-4">
+                            <label for="pointPositifs">Cas confirmés</label>
+                            <input type="number" class="form-control" id="pointPositifs" name="positive">
+                        </div>
+                    </div>
                     <button type="submit" class="btn btn-primary">Enregistrer</button>
                 </form>
             </div>

--- a/templates/admin/view_map.html.twig
+++ b/templates/admin/view_map.html.twig
@@ -173,7 +173,13 @@
                 });
 
                 marker.addListener('mouseover', function() {
-                    pointInfo.setContent('<strong>' + p.name + '</strong><br>Zone: ' + p.zone);
+                    pointInfo.setContent(
+                        '<strong>' + p.name + '</strong><br>' +
+                        'Zone: ' + p.zone + '<br>' +
+                        'Habitants: ' + p.population + '<br>' +
+                        'Symptomatiques: ' + p.symptomatic + '<br>' +
+                        'Confirmés: ' + p.positive
+                    );
                     pointInfo.open(map, marker);
                 });
                 marker.addListener('mouseout', function() {

--- a/templates/admin/zone_edit.html.twig
+++ b/templates/admin/zone_edit.html.twig
@@ -21,20 +21,7 @@
                             {% endfor %}
                         </select>
                     </div>
-                    <div class="form-row">
-                        <div class="form-group col-md-4">
-                            <label for="zoneHabitants">Habitants</label>
-                            <input type="number" class="form-control" id="zoneHabitants" name="population" value="{{ zone.population }}">
-                        </div>
-                        <div class="form-group col-md-4">
-                            <label for="zoneSympto">Symptomatiques</label>
-                            <input type="number" class="form-control" id="zoneSympto" name="symptomatic" value="{{ zone.symptomatic }}">
-                        </div>
-                        <div class="form-group col-md-4">
-                            <label for="zonePositifs">Cas confirmés</label>
-                            <input type="number" class="form-control" id="zonePositifs" name="positive" value="{{ zone.positive }}">
-                        </div>
-                    </div>
+                    {# Les compteurs sont mis à jour à partir des points de surveillance (hôpitaux) #}
                     <button type="submit" class="btn btn-primary">Enregistrer</button>
                 </form>
             </div>

--- a/templates/admin/zone_list.html.twig
+++ b/templates/admin/zone_list.html.twig
@@ -18,7 +18,7 @@
                                 <th>Habitants</th>
                                 <th>Symptomatiques</th>
                                 <th>Confirmés</th>
-                                <th>Point de surveillance</th>
+                                <th>Points</th>
                                 {% if is_granted('ROLE_AGENT') %}<th>Actions</th>{% endif %}
                             </tr>
                         </thead>

--- a/templates/admin/zone_new.html.twig
+++ b/templates/admin/zone_new.html.twig
@@ -25,22 +25,7 @@
 
                         </select>
                     </div>
-                    <div class="form-row">
-                        <div class="form-group col-md-4">
-                            <label for="zoneHabitants">Habitants</label>
-                            <input type="number" class="form-control" id="zoneHabitants" name="population">
-                        </div>
-                        <div class="form-group col-md-4">
-                            <label for="zoneSympto">Symptomatiques</label>
-                            <input type="number" class="form-control" id="zoneSympto" name="symptomatic">
-                        </div>
-                        <div class="form-group col-md-4">
-                            <label for="zonePositifs">Cas confirmés</label>
-                            <input type="number" class="form-control" id="zonePositifs" name="positive">
-
-                        </div>
-                    </div>
-                    {# Le statut est calculé automatiquement #}
+                    {# Les compteurs sont renseignés automatiquement via les points de surveillance (hôpitaux) #}
                     <button type="submit" class="btn btn-primary">Enregistrer</button>
                 </form>
             </div>


### PR DESCRIPTION
## Summary
- integrate Gmail API to send alerts when a zone turns red
- document Gmail API credentials in README
- add GmailApiMailer service and inject it into DashboardController

## Testing
- `php -l src/Service/GmailApiMailer.php`
- `php -l src/Controller/DashboardController.php`
- `find src templates -name '*.php' -o -name '*.twig' | xargs -I{} php -l {}`
- `php -l migrations/Version20250712005341.php`
- `vendor/bin/phpunit --configuration phpunit.dist.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6871ac321b24832398f8b3210d8ae09b